### PR TITLE
remove petrol-gas-shift and speed up traditional biomass phase-out

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '701715'
+ValidationKey: '722016'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.3.5
-date-released: '2024-11-22'
+version: 0.3.6
+date-released: '2024-11-29'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.3.5
+Version: 0.3.6
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -59,5 +59,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2024-11-22
+Date: 2024-11-29
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.3.5**
+R package **edgebuildings**, version **0.3.6**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings)  [![R build status](https://github.com/robinhasse/edgebuildings/workflows/check/badge.svg)](https://github.com/robinhasse/edgebuildings/actions) [![codecov](https://codecov.io/gh/robinhasse/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/robinhasse/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings)  [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2024). _edgebuildings: Model for the projection of global energy demand in the buildings sector_. R package version 0.3.5.
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2024). _edgebuildings: Model for the projection of global energy demand in the buildings sector_. R package version 0.3.6.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,6 +64,6 @@ A BibTeX entry for LaTeX users is
   title = {edgebuildings: Model for the projection of global energy demand in the buildings sector},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
   year = {2024},
-  note = {R package version 0.3.5},
+  note = {R package version 0.3.6},
 }
 ```

--- a/inst/config/config_remind.csv
+++ b/inst/config/config_remind.csv
@@ -30,23 +30,23 @@ econCoef_water_heating.elecHP_eff_X_Asym;;5;5;6;5;5;5;5;5;5;3.875;5,lowIncome:3.
 econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.8;0.9;0.75;0.8;0.5;0.5;0.5;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
 econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
-feShare_space_heating_natgas;;15;15;5;15;15;46,Europe:35.5;46,Europe:35.5;15;15;40;35,lowIncome:40,highIncome:75;75
-feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;31,Europe:28;31,Europe:28;75;40;15;40,lowIncome:15,highIncome:17;17
-feShare_space_heating_heat;;35;30;25;35;35;10,Europe:22;10,Europe:22;6.25;35;15;15,highIncome:3;3
-feShare_space_heating_petrol;;5;5;5;5;5;7,Europe:3.5;7,Europe:3.5;1.875;5;15;5,lowIncome:15,highIncome:2;2
-feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;6,Europe:11;6,Europe:11;1.875;5;15;5,lowIncome:15,highIncome:3;3
-feShare_water_heating_natgas;;15;15;5;15;15;37.5,Europe:33.5;37.5,Europe:33.5;15;15;40;35,lowIncome:40,highIncome:75;75
-feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;34,Europe:34;34,Europe:34;75;40;15;40,lowIncome:15,highIncome:17;17
-feShare_water_heating_heat;;35;30;25;35;35;13,Europe:23;13,Europe:23;6.25;35;15;15,highIncome:3;3
-feShare_water_heating_petrol;;5;5;5;5;5;5.5,Europe:2.5;5.5,Europe:2.5;1.875;5;15;5,lowIncome:15,highIncome:2;2
-feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;9.5,Europe:7;9.5,Europe:7;1.875;5;15;5,lowIncome:15,highIncome:3;3
-feShare_cooking_natgas;;15;15;5;15;15;37,Europe:39;37,Europe:39;45;15;65;45,lowIncome:65,highIncome:78;78
-feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;41,Europe:53;41,Europe:53;50;80;15;50,lowIncome:15,highIncome:15;15
+feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
+feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
+feShare_space_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;6.25;35;15;15,highIncome:3;3
+feShare_space_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
+feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
+feShare_water_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
+feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
+feShare_water_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;6.25;35;15;15,highIncome:3;3
+feShare_water_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
+feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
+feShare_cooking_natgas;;15;15;5;15;15;45,Europe:46;45,Europe:46;45;15;65;45,lowIncome:65,highIncome:78;78
+feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;50,Europe:52;50,Europe:52;50;80;15;50,lowIncome:15,highIncome:15;15
 feShare_cooking_heat;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;14,Europe:6;14,Europe:6;5;5;20;5,lowIncome:20,highIncome:2;2
-feShare_cooking_biomod;;0;0;0;0;0;8,Europe:2;8,Europe:2;0;0;0;0;0
-feShare_appliances_light_elec;;100;100;100;100;100;96,Europe:100;96,Europe:100;100;100;100;100;100
-feShare_appliances_light_natgas;;0;0;0;0;0;3,Europe:0;3,Europe:0;0;0;0;0;0
+feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;5,Europe:2;5,Europe:2;5;5;20;5,lowIncome:20,highIncome:2;2
+feShare_cooking_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_appliances_light_elec;;100;100;100;100;100;100;100;100;100;100;100;100
+feShare_appliances_light_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
 feShare_appliances_light_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
 feShare_space_cooling_elec;;100;100;100;100;100;100;100;100;100;100;100;100
 feShare_space_cooling_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
@@ -55,7 +55,6 @@ feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
 speed;;2200;2200;2200;2200;2200;2300;2300;2100;2200;2400;2400,lowIncome:2500,highIncome:2300;2200
 speed_fullconv;;2070;2070;2070;2070;2070;2070;2070;2070;;2070;2070;2070
 floorspaceCap;;60;75;50;40;NA;NA;NA;40;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;30000;30000;30000;30000;30000;30000;30000;30000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;20000;20000;20000;20000;20000;20000;20000;20000
 gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0;0
 interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE
-speed_feShare;;2150;2150;2150;2150;2150;2100;2100;2150;2150;2150;2150;2150

--- a/man/buildScenInput.Rd
+++ b/man/buildScenInput.Rd
@@ -6,8 +6,7 @@
 \usage{
 buildScenInput(
   config,
-  subtype = c("scen_assump", "scen_assump_speed", "scen_assump_corr", "fe_shares",
-    "mapping"),
+  subtype = c("scen_assump", "scen_assump_speed", "fe_shares", "mapping"),
   regionmap,
   singleScen = TRUE,
   valueOnly = FALSE

--- a/man/dot-expandToRegions.Rd
+++ b/man/dot-expandToRegions.Rd
@@ -16,7 +16,7 @@
 \item{prefix}{common switch prefix that will be removed}
 }
 \value{
-data.frame witch switch values for each scenario and region
+data.frame with switch values for each scenario and region
 }
 \description{
 Convert config to data frame with values for each region


### PR DESCRIPTION
- set the convergence year for FE target shares to 2150 again
- set the FE target shares in SSP2 to the value used before (when the convergence year also was 2150)
These two changes together restore the old behavior of the FE target share projection and remove the shift of shares from petrol to gas.
- speed up traditional biomass, coal and petrol-in-lighting phase out by lowering the GDP threshold to 20.000.