### PR TITLE
Add per capita floorspace plots

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6240300'
+ValidationKey: '6260741'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.3.10
-date-released: '2025-02-11'
+version: 0.3.11
+date-released: '2025-02-12'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.3.10
+Version: 0.3.11
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -61,5 +61,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2025-02-11
+Date: 2025-02-12
 VignetteBuilder: knitr

--- a/R/visualiseScenarios.R
+++ b/R/visualiseScenarios.R
@@ -279,6 +279,66 @@ visualiseScenarios <- function(path, outputFile = NULL) {
   i <- i + length(.regions(pData))
 
 
+  ## per capita Floorspace ====
+
+  bookmarks <- .addBookmark(bookmarks, "Floor space per capita", i, 1)
+
+
+  pData <- data %>%
+    filter(.data[["variable"]] %in% c("buildings", "pop", "gdp")) %>%
+    .aggREMIND(recover = "DEU") %>%
+    select(-"unit") %>%
+    pivot_wider(names_from = "variable") %>%
+    mutate(gdppop = .data[["gdp"]] / .data[["pop"]],
+           buildings_pop = .data[["buildings"]] / .data[["pop"]]) # million m2/millioncap = m2/cap
+
+
+  ### all regions ####
+
+  p <- lapply(list("period", "gdppop"), function(x) {
+    linePlot(
+      pData,
+      title = switch(x, period = paste("Total floor space per capita")),
+      xAxisLabel = x,
+      yAxisLabel = switch(x, period = "m2/cap"),
+      linetypes = linetypes,
+      facet = "scenario",
+      color = "region",
+      x = x,
+      y = "buildings_pop"
+    ) + switch(x, gdppop = theme(axis.text.y = element_blank(),
+                                 axis.ticks.y = element_blank()))
+  })
+  print(ggarrange(plotlist = p, ncol = 2, common.legend = TRUE ,legend = "right",
+                  widths = c(1.2, 1), align = "hv"))
+
+  i <- i + 1
+
+
+  ### regional ####
+
+  for (r in .regions(pData)) {
+    p <- lapply(list("period", "gdppop"), function(x) {
+      linePlot(
+        filter(pData, .data[["region"]] %in% r),
+        title = switch(x, period = paste("Total floor space per capita")),
+        subtitle = switch(x, period = r),
+        xAxisLabel = x,
+        yAxisLabel = switch(x, period = "m2/cap"),
+        linetypes = linetypes,
+        color = "scenario",
+        x = x,
+        y = "buildings_pop"
+      ) + switch(x, gdppop = theme(axis.text.y = element_blank(),
+                                   axis.ticks.y = element_blank()))
+    })
+    print(ggarrange(plotlist = p, ncol = 2, common.legend = TRUE ,legend = "right",
+                    widths = c(1.2, 1), align = "hv"))
+  }
+
+  i <- i + length(.regions(pData))
+
+
   ## energy demand====
 
   bookmarks <- .addBookmark(bookmarks, "Energy demand", i, 1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.3.10**
+R package **edgebuildings**, version **0.3.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.10."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.11."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.10},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.11},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
-  date = {2025-02-11},
+  date = {2025-02-12},
   year = {2025},
 }
 ```


### PR DESCRIPTION
Add plots with per capita floorspace to ```visualiseScenarios```-output. Example: 
[projections.pdf](https://github.com/user-attachments/files/18705299/projections.pdf)
