### PR TITLE
Implement change of macro driver scenario names

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '785070'
+ValidationKey: '6240300'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.3.9
+version: 0.3.10
 date-released: '2025-02-11'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.3.9
+Version: 0.3.10
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),

--- a/R/buildingsProjections.R
+++ b/R/buildingsProjections.R
@@ -122,17 +122,15 @@ buildingsProjections <- function(config,
 
   # population
   pop <- pop %>%
-    filter(.data[["variable"]] == config[, "popScen"]) %>%
+    filter(.data[["scenario"]] == config[, "popScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     as.quitte()
 
   # gdppop
   gdppop <- gdppop  %>%
-    filter(.data[["variable"]] == config[, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     as.quitte()
 

--- a/R/getDensity.R
+++ b/R/getDensity.R
@@ -28,7 +28,6 @@ getDensity <- function(fulltime = FALSE,
     mutate(density = .data[["pop"]] * million2unit / .data[["surface"]]) %>%
     dplyr::select(-"pop", -"surface") %>%
     gather(key = "variable", value = "value", "density") %>%
-    unite(col = "variable", "variable", "scenario", sep = "_") %>%
     filter(.data[["value"]] != 0) %>%
     as.data.frame() %>%
     as.quitte() %>%

--- a/R/getFEUEefficiencies.R
+++ b/R/getFEUEefficiencies.R
@@ -119,9 +119,8 @@ getFEUEefficiencies <- function(config,
 
   # gdppop
   gdppop <- gdppop  %>%
-    filter(.data[["variable"]] == config[, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen)
 
 

--- a/R/getFloorspaceResidential.R
+++ b/R/getFloorspaceResidential.R
@@ -95,25 +95,22 @@ getFloorspaceResidential <- function(config,
 
   # gdppop
   gdppop <- gdppop %>%
-    filter(.data[["variable"]] == config[scen, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[scen, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     missingToNA()
 
   # pop
   pop <- pop %>%
-    filter(.data[["variable"]] == config[scen, "popScen"]) %>%
+    filter(.data[["scenario"]] == config[scen, "popScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     missingToNA()
 
   # density
   density <- density %>%
-    filter(.data[["variable"]] == config[scen, "densityScen"]) %>%
+    filter(.data[["scenario"]] == config[scen, "densityScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     missingToNA()
 

--- a/R/getGDP.R
+++ b/R/getGDP.R
@@ -31,7 +31,7 @@ getGDP <- function(config,
 
   # gdp
   gdp <- gdp %>%
-    filter(.data[["variable"]] == config[scen, "gdpScen"])
+    filter(.data[["scenario"]] == config[scen, "gdpScen"])
 
   # gdpBoost
   gdpBoost <- config[scen, "gdpBoost"]
@@ -71,7 +71,7 @@ getGDP <- function(config,
   # OUTPUT----------------------------------------------------------------------
 
   gdp <- gdp %>%
-    select("region", "period", "variable", "value")
+    select("region", "period", "scenario", "variable", "value")
 
   return(gdp)
 }

--- a/R/getGDPpop.R
+++ b/R/getGDPpop.R
@@ -16,13 +16,9 @@
 
 getGDPpop <- function(pop, gdp, fulltime = FALSE) {
 
-  pop <- sepVarScen(pop)
-  gdp <- sepVarScen(gdp)
-
   gdppop <- bind_rows(pop, gdp) %>%
     unique() %>%
     calc_addVariable(gdppop = "gdp / pop", only.new = TRUE) %>%
-    unite(col = "variable", "variable", "scenario", sep = "_") %>%
     as.quitte() %>%
     missingToNA()
 

--- a/R/getShareECprojections.R
+++ b/R/getShareECprojections.R
@@ -136,9 +136,8 @@ getShareECprojections <- function(config,
 
   # gdppop
   gdppop <- gdppop %>%
-    filter(.data[["variable"]] == config[, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     filter(.data[["period"]] %in% years) %>%
     sepHistScen(endOfHistory = endOfHistory) %>%
@@ -147,9 +146,8 @@ getShareECprojections <- function(config,
 
   # gdp
   gdp <- gdp %>%
-    filter(.data[["variable"]] == config[, "gdpScen"]) %>%
+    filter(.data[["scenario"]] == config[, "gdpScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     filter(.data[["period"]] %in% years) %>%
     sepHistScen(endOfHistory = endOfHistory) %>%

--- a/R/getShareFloorCommercial.R
+++ b/R/getShareFloorCommercial.R
@@ -65,18 +65,16 @@ getShareFloorCommercial <- function(config,
 
   # prepare gdppop
   gdppop <- gdppop %>%
-    filter(.data[["variable"]] == config[scen, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[scen, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     mutate(value = as.numeric(.data[["value"]])) %>%
     dplyr::select("region", "period", "scenario", "variable", "value")
 
   # prepare population
   pop <- pop %>%
-    filter(.data[["variable"]] == config[, "popScen"]) %>%
+    filter(.data[["scenario"]] == config[, "popScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen) %>%
     mutate(value = as.numeric(.data[["value"]]))
 

--- a/R/getUvalues.R
+++ b/R/getUvalues.R
@@ -70,9 +70,8 @@ getUvalues <- function(config,
 
   # gdppop
   gdppop <- gdppop %>%
-    filter(.data[["variable"]] == config[, "gdppopScen"]) %>%
+    filter(.data[["scenario"]] == config[, "gdppopScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen)
 
 
@@ -83,9 +82,8 @@ getUvalues <- function(config,
 
   # population
   pop <- pop %>%
-    filter(.data[["variable"]] == config[, "popScen"]) %>%
+    filter(.data[["scenario"]] == config[, "popScen"]) %>%
     unique() %>%
-    sepVarScen() %>%
     mutate(scenario = scen)
 
 

--- a/R/makeProjections.R
+++ b/R/makeProjections.R
@@ -253,7 +253,7 @@ makeProjections <- function(df,
     ungroup() %>%
 
     # determine deviation between projections and last historical point
-    mutate_text(deltaFormula()) %>%
+    mutate_text(deltaFormula) %>%
     select("region", "delta") %>%
     rbind(data.frame(region = "GLO", delta = deltaGlobalTarget))
 

--- a/R/runEdgeBuildings.R
+++ b/R/runEdgeBuildings.R
@@ -19,7 +19,7 @@ runEdgeBuildings <- function(config = "configEDGEscens.csv",
                              outputDir = "./output",
                              reporting = NULL,
                              madratDir = NULL,
-                             inputdataRevision = "0.4.2",
+                             inputdataRevision = "0.4.4",
                              forceDownload = FALSE) {
 
   # TODO: relocate data_internal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.3.9**
+R package **edgebuildings**, version **0.3.10**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings)  [![R build status](https://github.com/hagento/edgebuildings/workflows/check/badge.svg)](https://github.com/hagento/edgebuildings/actions) [![codecov](https://codecov.io/gh/hagento/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/hagento/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). _edgebuildings: Model for the projection of global energy demand in the buildings sector_. R package version 0.3.9.
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.10."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector},
+@Misc{,
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.3.10},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
+  date = {2025-02-11},
   year = {2025},
-  note = {R package version 0.3.9},
 }
 ```

--- a/inst/_targets.R
+++ b/inst/_targets.R
@@ -341,22 +341,24 @@ list(
   tar_target(
     pop,
     {
-      cols <- c("period", "region", "variable", "value")
+      cols <- c("period", "region", "scenario", "value")
       file <- pop.cs4r
 
       read.csv2(file, skip = skiprow(file), sep = ",", col.names = cols) %>%
-        mutate(value = as.numeric(.data[["value"]]))
+        mutate(value = as.numeric(.data[["value"]]), variable = "pop") %>%
+        dplyr::relocate("variable", .after = "scenario")
     }),
 
   # gdp
   tar_target(
     gdpInput,
     {
-      cols <- c("period", "region", "variable", "value")
+      cols <- c("period", "region", "scenario", "value")
       file <- gdp.cs4r
 
       read.csv2(file, skip = skiprow(file), sep = ",", col.names = cols) %>%
-        mutate(value = as.numeric(.data[["value"]]))
+        mutate(value = as.numeric(.data[["value"]]), variable = "gdp") %>%
+        dplyr::relocate("variable", .after = "scenario")
     }),
 
   # population density
@@ -365,8 +367,7 @@ list(
     {
 
       getDensity(pop = pop %>%
-                   filter(variable == config[, "popScen"]) %>%
-                   sepVarScen(),
+                   filter(scenario == config[, "popScen"]),
                  surface = surface)
     },
     pattern = map(config),
@@ -403,9 +404,9 @@ list(
   tar_target(
     gdppop,{
       getGDPpop(pop = pop %>%
-                  filter(variable == config[, "popScen"]),
+                  filter(scenario == config[, "popScen"]),
                 gdp = gdp %>%
-                  filter(variable == config[, "gdpScen"]))
+                  filter(scenario == config[, "gdpScen"]))
     },
     pattern = map(config),
     iteration = "vector"

--- a/inst/config/configEDGEscens.csv
+++ b/inst/config/configEDGEscens.csv
@@ -1,11 +1,11 @@
 parameter;valueComment;SSP1;SSP2;SSP3;SSP4;SSP5
-popScen;;pop_SSP1;pop_SSP2;pop_SSP3;pop_SSP4;pop_SSP5
-gdpScen;;gdp_SSP1;gdp_SSP2;gdp_SSP3;gdp_SSP4;gdp_SSP5
-urbanisationScen;;pop_SSP1;pop_SSP2;pop_SSP3;pop_SSP4;pop_SSP5
-densityScen;;density_SSP1;density_SSP2;density_SSP3;density_SSP4;density_SSP5
+popScen;;SSP1;SSP2;SSP3;SSP4;SSP5
+gdpScen;;SSP1;SSP2;SSP3;SSP4;SSP5
+urbanisationScen;;SSP1;SSP2;SSP3;SSP4;SSP5
+densityScen;;SSP1;SSP2;SSP3;SSP4;SSP5
 floorScen;;SSP1;SSP2;SSP3;SSP4;SSP5
 uvalueScen;;SSP1;SSP2;SSP3;SSP4;SSP5
-gdppopScen;;gdppop_SSP1;gdppop_SSP2;gdppop_SSP3;gdppop_SSP4;gdppop_SSP5
+gdppopScen;;SSP1;SSP2;SSP3;SSP4;SSP5
 hddcddScen;;SSP1;SSP2;SSP3;SSP4;SSP5
 rcpScen;;noCC;noCC;noCC;noCC;noCC
 tlimTarget_HDD;set point temperature target for space heating in degC;13;14;14;14;16

--- a/inst/config/configFull.csv
+++ b/inst/config/configFull.csv
@@ -1,59 +1,59 @@
-parameter;valueComment;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2EU;SSP2_lowEn;SSP3;SSP4;SSP5;SSP5_OS;picontrol
-popScen;;pop_SDP;pop_SDP_EI;pop_SDP_MC;pop_SDP_RC;pop_SSP1;pop_SSP2;pop_SSP2EU;pop_SSP2EU;pop_SSP3;pop_SSP4;pop_SSP5;pop_SSP5;pop_SSP2
-gdpScen;;gdp_SDP;gdp_SDP_EI;gdp_SDP_MC;gdp_SDP_RC;gdp_SSP1;gdp_SSP2;gdp_SSP2EU;gdp_SSP2EU;gdp_SSP3;gdp_SSP4;gdp_SSP5;gdp_SSP5;gdp_SSP2
-urbanisationScen;;pop_SDP;pop_SDP_EI;pop_SDP_MC;pop_SDP_RC;pop_SSP1;pop_SSP2;pop_SSP2EU;pop_SSP2EU;pop_SSP3;pop_SSP4;pop_SSP5;pop_SSP5;pop_SSP2
-densityScen;;density_SDP;density_SDP_EI;density_SDP_MC;density_SDP_RC;density_SSP1;density_SSP2;density_SSP2EU;density_SSP2EU;density_SSP3;density_SSP4;density_SSP5;density_SSP5;density_SSP2
-floorScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
-gdppopScen;;gdppop_SDP;gdppop_SDP_EI;gdppop_SDP_MC;gdppop_SDP_RC;gdppop_SSP1;gdppop_SSP2;gdppop_SSP2EU;gdppop_SSP2EU;gdppop_SSP3;gdppop_SSP4;gdppop_SSP5;gdppop_SSP5;gdppop_SSP2
-hddcddScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;picontrol
-rcpScen;;1.9;1.9;1.9;1.9;2.6;4.5;4.5;4.5;7;6;8.5;3.4;picontrol
-tlimHist_HDD;historical set point temperature for space heating in degC;14;14;14;14;14;14;14;14;14;14;14;14;14
-tlimHist_CDD;historical set point temperature for space cooling in degC;20;20;20;20;20;20;20;20;20;20;20;20;20
-tlimTarget_HDD;set point temperature target for space heating in degC;13;13;13;12;13;14;14;13;14;14;16;16;14
-tlimTarget_CDD;set point temperature target for space cooling in degC;21;21;21;22;21;20;20;20;20;20;20;20;20
-speed_HDD;year in which HDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
-speed_CDD;year in which CDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
-econCoef_floorspace;RC people are happy with less space;0.3;0.3;0.25;0.2;0.3;0.7;0.7;0.3;0.8;0.7,lowIncome:0.8;1;1;0.7
-econCoef_space_heating_m2_Uval_X_HDD;;1;1;1;1;1;1;1;1;1;1;1;1;1
-econCoef_appliances_light_pop_X_gdppop;RC people are happy with less light, MC stricter efficiency rules;0.8;0.8;0.7;0.6;0.8;1;1;0.8;1;1,highIncome:1.3;1.3;1.3;1
-econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC stricter efficiency rules;0.7;0.7;0.6;0.5;0.7;1;1;0.7;1.1;1,lowIncome:1.1,highIncome:1.15;1.3;1.3;1
-econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;0.7;0.7;0.6;0.5;0.7;1;1;0.7;1.25;1;1.3;1.3;1
-econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.2;0.2;0.15;0.05;0.3;0.6;0.6;0.3;1;1,highIncome:1.3;1.3;1.3;0.6
-econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1;1;1
-econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.35;0.7;0.7;0.35;0.85;0.75,lowIncome:0.85;0.75;0.75;0.7
-econCoef_biotrad;;2;2;2;2;2;1;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5;1.5;1
-econCoef_space_heating.elec_X_Asym;RC a little less efficient, MC more efficient;4.2;4.2;5.5;4;4.2;3,Europe:4;3,Europe:4;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3,Europe:4
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334;-10.46310334;-10.1266311,Europe:-10
-econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;5;5;3.875;5,lowIncome:3.875;8;8;5
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
-econCoef_water_heating.elec_X_Asym;;4.2;4.2;5.5;4;4.2;3;3;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
-econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9;0.9;0.9
-feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;40;35,lowIncome:40,highIncome:75;75;75;35,Europe:32
-feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;40;15;40,lowIncome:15,highIncome:17;17;17;40,Europe:37
-feShare_space_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;35;15;15,highIncome:3;3;3;15,Europe:25
-feShare_space_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;5;15;5,lowIncome:15,highIncome:2;2;2;5,Europe:2
-feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;5;15;5,lowIncome:15,highIncome:3;3;3;5,Europe:4
-feShare_water_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;40;35,lowIncome:40,highIncome:75;75;75;35,Europe:32
-feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;40;15;40,lowIncome:15,highIncome:17;17;17;40,Europe:37
-feShare_water_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;35;15;15,highIncome:3;3;3;15,Europe:25
-feShare_water_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;5;15;5,lowIncome:15,highIncome:2;2;2;5,Europe:2
-feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;5;15;5,lowIncome:15,highIncome:3;3;3;5,Europe:4
-feShare_cooking_natgas;;15;15;5;15;15;45,Europe:46;45,Europe:46;15;65;45,lowIncome:65,highIncome:78;78;78;45,Europe:46
-feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;50,Europe:52;50,Europe:52;80;15;50,lowIncome:15,highIncome:15;15;15;50,Europe:52
-feShare_cooking_heat;;0;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;5,Europe:2;5,Europe:2;5;20;5,lowIncome:20,highIncome:2;2;2;5,Europe:2
-feShare_cooking_biomod;;0;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_appliances_light_elec;;100;100;100;100;100;100;100;100;100;100;100;100;100
-feShare_appliances_light_natgas;;0;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_appliances_light_biomod;;0;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_space_cooling_elec;;70;70;70;70;70;90;90;70;95;90,highIncome:95;95;95;90
-feShare_space_cooling_natgas;;0;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_space_cooling_heat;;30;30;30;30;30;10;10;30;5;10,highIncome:5;5;5;10
-feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0;0;0
-speed;;2200;2200;2200;2200;2200;2300;2300;2200;2400;2400,lowIncome:2500,highIncome:2300;2200;2200;2300
-speed_fullconv;;2070;2070;2070;2070;2070;2070;2070;;2070;2070;2070;2070;2070
-floorspaceCap;;60;75;50;40;NA;NA;NA;NA;NA;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;30000;30000;30000;30000;30000;30000;30000;30000;30000
-gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0;0;0
-interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE
+parameter;valueComment;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2_lowEn;SSP3;SSP4;SSP5;SSP5_OS;picontrol
+popScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+gdpScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+urbanisationScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+densityScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+floorScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+gdppopScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;SSP2
+hddcddScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP3;SSP4;SSP5;SSP5;picontrol
+rcpScen;;1.9;1.9;1.9;1.9;2.6;4.5;4.5;7;6;8.5;3.4;picontrol
+tlimHist_HDD;historical set point temperature for space heating in degC;14;14;14;14;14;14;14;14;14;14;14;14
+tlimHist_CDD;historical set point temperature for space cooling in degC;20;20;20;20;20;20;20;20;20;20;20;20
+tlimTarget_HDD;set point temperature target for space heating in degC;13;13;13;12;13;14;13;14;14;16;16;14
+tlimTarget_CDD;set point temperature target for space cooling in degC;21;21;21;22;21;20;20;20;20;20;20;20
+speed_HDD;year in which HDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
+speed_CDD;year in which CDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
+econCoef_floorspace;RC people are happy with less space;0.3;0.3;0.25;0.2;0.3;0.7;0.3;0.8;0.7,lowIncome:0.8;1;1;0.7
+econCoef_space_heating_m2_Uval_X_HDD;;1;1;1;1;1;1;1;1;1;1;1;1
+econCoef_appliances_light_pop_X_gdppop;RC people are happy with less light, MC stricter efficiency rules;0.8;0.8;0.7;0.6;0.8;1;0.8;1;1,highIncome:1.3;1.3;1.3;1
+econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC stricter efficiency rules;0.7;0.7;0.6;0.5;0.7;1;0.7;1.1;1,lowIncome:1.1,highIncome:1.15;1.3;1.3;1
+econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;0.7;0.7;0.6;0.5;0.7;1;0.7;1.25;1;1.3;1.3;1
+econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.2;0.2;0.15;0.05;0.3;0.6;0.3;1;1,highIncome:1.3;1.3;1.3;0.6
+econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1;1
+econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.35;0.7;0.35;0.85;0.75,lowIncome:0.85;0.75;0.75;0.7
+econCoef_biotrad;;2;2;2;2;2;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5;1.5;1
+econCoef_space_heating.elec_X_Asym;RC a little less efficient, MC more efficient;4.2;4.2;5.5;4;4.2;3,Europe:4;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3,Europe:4
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334;-10.46310334;-10.1266311,Europe:-10
+econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;5;3.875;5,lowIncome:3.875;8;8;5
+econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
+econCoef_water_heating.elec_X_Asym;;4.2;4.2;5.5;4;4.2;3;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3
+econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
+econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9;0.9;0.9
+feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;15;40;35,lowIncome:40,highIncome:75;75;75;35,Europe:32
+feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40;15;40,lowIncome:15,highIncome:17;17;17;40,Europe:37
+feShare_space_heating_heat;;35;30;25;35;35;15,Europe:25;35;15;15,highIncome:3;3;3;15,Europe:25
+feShare_space_heating_petrol;;5;5;5;5;5;5,Europe:2;5;15;5,lowIncome:15,highIncome:2;2;2;5,Europe:2
+feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5;15;5,lowIncome:15,highIncome:3;3;3;5,Europe:4
+feShare_water_heating_natgas;;15;15;5;15;15;35,Europe:32;15;40;35,lowIncome:40,highIncome:75;75;75;35,Europe:32
+feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40;15;40,lowIncome:15,highIncome:17;17;17;40,Europe:37
+feShare_water_heating_heat;;35;30;25;35;35;15,Europe:25;35;15;15,highIncome:3;3;3;15,Europe:25
+feShare_water_heating_petrol;;5;5;5;5;5;5,Europe:2;5;15;5,lowIncome:15,highIncome:2;2;2;5,Europe:2
+feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5;15;5,lowIncome:15,highIncome:3;3;3;5,Europe:4
+feShare_cooking_natgas;;15;15;5;15;15;45,Europe:46;15;65;45,lowIncome:65,highIncome:78;78;78;45,Europe:46
+feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;50,Europe:52;80;15;50,lowIncome:15,highIncome:15;15;15;50,Europe:52
+feShare_cooking_heat;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;5,Europe:2;5;20;5,lowIncome:20,highIncome:2;2;2;5,Europe:2
+feShare_cooking_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_appliances_light_elec;;100;100;100;100;100;100;100;100;100;100;100;100
+feShare_appliances_light_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_appliances_light_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_space_cooling_elec;;70;70;70;70;70;90;70;95;90,highIncome:95;95;95;90
+feShare_space_cooling_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
+feShare_space_cooling_heat;;30;30;30;30;30;10;30;5;10,highIncome:5;5;5;10
+feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
+speed;;2200;2200;2200;2200;2200;2300;2200;2400;2400,lowIncome:2500,highIncome:2300;2200;2200;2300
+speed_fullconv;;2070;2070;2070;2070;2070;2070;;2070;2070;2070;2070;2070
+floorspaceCap;;60;75;50;40;NA;NA;NA;NA;NA;NA;NA;NA
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;30000;30000;30000;30000;30000;30000;30000;30000
+gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0;0
+interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/configSSP2-Impact.csv
+++ b/inst/config/configSSP2-Impact.csv
@@ -1,11 +1,11 @@
 parameter;valueComment;SSP2-1.9;SSP2-2.6;SSP2-4.5;SSP2-6.0;SSP2-7.0;SSP2-noCC
-popScen;;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2
-gdpScen;;gdp_SSP2;gdp_SSP2;gdp_SSP2;gdp_SSP2;gdp_SSP2;gdp_SSP2
-urbanisationScen;;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2;pop_SSP2
-densityScen;;density_SSP2;density_SSP2;density_SSP2;density_SSP2;density_SSP2;density_SSP2
+popScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
+gdpScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
+urbanisationScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
+densityScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
 floorScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
 uvalueScen;;SSP2-noCC;SSP2-noCC;SSP2-noCC;SSP2-noCC;SSP2-noCC;SSP2-noCC
-gdppopScen;;gdppop_SSP2;gdppop_SSP2;gdppop_SSP2;gdppop_SSP2;gdppop_SSP2;gdppop_SSP2
+gdppopScen;;SSP2;SSP2;SSP2;SSP2;SSP2;SSP2
 hddcddScen;;SSP1;SSP1;SSP2;SSP4;SSP3;SSP2
 rcpScen;;1.9;2.6;4.5;6;7;noCC
 tlimHist_HDD;historical set point temperature for space heating in degC;14;14;14;14;14;14

--- a/inst/config/configTest.csv
+++ b/inst/config/configTest.csv
@@ -1,10 +1,10 @@
 parameter;valueComment;SSP5_OS;picontrol
-popScen;;pop_SSP5;pop_SSP2
-gdpScen;;gdp_SSP5;gdp_SSP2
-urbanisationScen;;pop_SSP5;pop_SSP2
-densityScen;;density_SSP5;density_SSP2
+popScen;;SSP5;SSP2
+gdpScen;;SSP5;SSP2
+urbanisationScen;;SSP5;SSP2
+densityScen;;SSP5;SSP2
 floorScen;;SSP5;SSP2
-gdppopScen;;gdppop_SSP5;gdppop_SSP2
+gdppopScen;;SSP5;SSP2
 hddcddScen;;SSP5;picontrol
 rcpScen;;3.4;picontrol
 tlimHist_HDD;historical set point temperature for space heating in degC;14;14

--- a/inst/config/config_remind.csv
+++ b/inst/config/config_remind.csv
@@ -1,60 +1,60 @@
-parameter;valueComment;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2EU;SSP2EU_NAV_all;SSP2_lowEn;SSP3;SSP4;SSP5
-popScen;;pop_SDP;pop_SDP_EI;pop_SDP_MC;pop_SDP_RC;pop_SSP1;pop_SSP2;pop_SSP2;pop_SSP2EU;pop_SSP2EU;pop_SSP3;pop_SSP4;pop_SSP5
-gdpScen;;gdp_SDP;gdp_SDP_EI;gdp_SDP_MC;gdp_SDP_RC;gdp_SSP1;gdp_SSP2;gdp_SSP2;gdp_SSP2EU;gdp_SSP2EU;gdp_SSP3;gdp_SSP4;gdp_SSP5
-urbanisationScen;;pop_SDP;pop_SDP_EI;pop_SDP_MC;pop_SDP_RC;pop_SSP1;pop_SSP2;pop_SSP2;pop_SSP2EU;pop_SSP2EU;pop_SSP3;pop_SSP4;pop_SSP5
-densityScen;;density_SDP;density_SDP_EI;density_SDP_MC;density_SDP_RC;density_SSP1;density_SSP2;density_SSP2;density_SSP2EU;density_SSP2EU;density_SSP3;density_SSP4;density_SSP5
-floorScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
-uvalueScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
-gdppopScen;;gdppop_SDP;gdppop_SDP_EI;gdppop_SDP_MC;gdppop_SDP_RC;gdppop_SSP1;gdppop_SSP2;gdppop_SSP2;gdppop_SSP2EU;gdppop_SSP2EU;gdppop_SSP3;gdppop_SSP4;gdppop_SSP5
-hddcddScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
-rcpScen;;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC
-tlimTarget_HDD;set point temperature target for space heating in degC;12;12;12;12;12;14;14;12;12;14;15;15
-tlimTarget_CDD;set point temperature target for space cooling in degC;22;22;23;25;22;20;20;22;22;20;19;19
-speed_HDD;year in which HDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
-speed_CDD;year in which CDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
-econCoef_floorspace;RC people are happy with less space;0.3;0.3;0.25;0.2;0.3;0.7;0.7;0.4;0.3;0.8;0.7,lowIncome:0.8;1
-econCoef_space_heating_m2_Uval_X_HDD;;1;1;1;1;1;1;1;1;1;1;1;1
-econCoef_appliances_light_pop_X_gdppop;RC people are happy with less light, MC stricter efficiency rules;0.8;0.8;0.7;0.6;0.8;1;1;1;0.8;1;1,highIncome:1.3;1.3
-econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC stricter efficiency rules;0.7,CHN:1.1;0.7,CHN:1.1;0.6,CHN:1;0.5,CHN:0.9;0.7,CHN:1.1;1,CHN:1.7;1,CHN:1.7;1,CHN:1.7;0.7,CHN:1.1;1.1,CHN:1.8;1,lowIncome:1.1,highIncome:1.15;1.3,CHN:1.8
-econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;0.7;0.7;0.6;0.5;0.7;1;1;1;0.7;1.25;1;1.3
-econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.2;0.2;0.15;0.05;0.3;0.6;0.6;0.6;0.3;1;1,highIncome:1.3;1.3
-econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1;1
-econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.35;0.7;0.7;0.4;0.35;0.85;0.75,lowIncome:0.85;0.75
-econCoef_biotrad;;2;2;2;2;2;1;1;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5
-econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;5;6;5;5;5;5;6;5;3.875;5,lowIncome:3.875,highIncome:5;6
-econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.8;0.9;0.75;0.8;0.5,Europe:0.75;0.5,Europe:0.75;0.5,Europe:0.75;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334
-econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;5;6.5;5;3.875;5,lowIncome:3.875;8
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
-econCoef_water_heating.elecHP_eff_X_Asym;;5;5;6;5;5;5;5;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
-econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.8;0.9;0.75;0.8;0.5;0.5;0.5;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
-econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
-feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
-feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
-feShare_space_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;6.25;35;15;15,highIncome:3;3
-feShare_space_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
-feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
-feShare_water_heating_natgas;;15;15;5;15;15;35,Europe:32;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
-feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
-feShare_water_heating_heat;;35;30;25;35;35;15,Europe:25;15,Europe:25;6.25;35;15;15,highIncome:3;3
-feShare_water_heating_petrol;;5;5;5;5;5;5,Europe:2;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
-feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
-feShare_cooking_natgas;;15;15;5;15;15;45,Europe:46;45,Europe:46;45;15;65;45,lowIncome:65,highIncome:78;78
-feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;50,Europe:52;50,Europe:52;50;80;15;50,lowIncome:15,highIncome:15;15
-feShare_cooking_heat;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;5,Europe:2;5,Europe:2;5;5;20;5,lowIncome:20,highIncome:2;2
-feShare_cooking_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_appliances_light_elec;;100;100;100;100;100;100;100;100;100;100;100;100
-feShare_appliances_light_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_appliances_light_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_space_cooling_elec;;100;100;100;100;100;100;100;100;100;100;100;100
-feShare_space_cooling_natgas;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_space_cooling_heat;;0;0;0;0;0;0;0;0;0;0;0;0
-feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
-speed;;2200;2200;2200;2200;2200;2300;2300;2100;2200;2400;2400,lowIncome:2500,highIncome:2300;2200
-speed_fullconv;;2070;2070;2070;2070;2070;2070;2070;2070;;2070;2070;2070
-floorspaceCap;;60;75;50;40;NA;NA;NA;40;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;20000;20000;20000;20000;20000;20000;20000;20000
-gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0;0
-interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE
+parameter;valueComment;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2_NAV_all;SSP2_lowEn;SSP3;SSP4;SSP5
+popScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+gdpScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+urbanisationScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+densityScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+floorScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+uvalueScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+gdppopScen;;SDP;SDP_EI;SDP_MC;SDP_RC;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+hddcddScen;;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP2;SSP2;SSP3;SSP4;SSP5
+rcpScen;;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC;noCC
+tlimTarget_HDD;set point temperature target for space heating in degC;12;12;12;12;12;14;12;12;14;15;15
+tlimTarget_CDD;set point temperature target for space cooling in degC;22;22;23;25;22;20;22;22;20;19;19
+speed_HDD;year in which HDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
+speed_CDD;year in which CDD limit temperature target will be reached;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100;2100
+econCoef_floorspace;RC people are happy with less space;0.3;0.3;0.25;0.2;0.3;0.7;0.4;0.3;0.8;0.7,lowIncome:0.8;1
+econCoef_space_heating_m2_Uval_X_HDD;;1;1;1;1;1;1;1;1;1;1;1
+econCoef_appliances_light_pop_X_gdppop;RC people are happy with less light, MC stricter efficiency rules;0.8;0.8;0.7;0.6;0.8;1;1;0.8;1;1,highIncome:1.3;1.3
+econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC stricter efficiency rules;0.7,CHN:1.1;0.7,CHN:1.1;0.6,CHN:1;0.5,CHN:0.9;0.7,CHN:1.1;1,CHN:1.7;1,CHN:1.7;0.7,CHN:1.1;1.1,CHN:1.8;1,lowIncome:1.1,highIncome:1.15;1.3,CHN:1.8
+econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;0.7;0.7;0.6;0.5;0.7;1;1;0.7;1.25;1;1.3
+econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.2;0.2;0.15;0.05;0.3;0.6;0.6;0.3;1;1,highIncome:1.3;1.3
+econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1
+econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.35;0.7;0.4;0.35;0.85;0.75,lowIncome:0.85;0.75
+econCoef_biotrad;;2;2;2;2;2;1;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5
+econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;5;6;5;5;5;6;5;3.875;5,lowIncome:3.875,highIncome:5;6
+econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.8;0.9;0.75;0.8;0.5,Europe:0.75;0.5,Europe:0.75;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334
+econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;6.5;5;3.875;5,lowIncome:3.875;8
+econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_water_heating.elecHP_eff_X_Asym;;5;5;6;5;5;5;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
+econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.8;0.9;0.75;0.8;0.5;0.5;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
+econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
+feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
+feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
+feShare_space_heating_heat;;35;30;25;35;35;15,Europe:25;6.25;35;15;15,highIncome:3;3
+feShare_space_heating_petrol;;5;5;5;5;5;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
+feShare_space_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
+feShare_water_heating_natgas;;15;15;5;15;15;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
+feShare_water_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
+feShare_water_heating_heat;;35;30;25;35;35;15,Europe:25;6.25;35;15;15,highIncome:3;3
+feShare_water_heating_petrol;;5;5;5;5;5;5,Europe:2;1.875;5;15;5,lowIncome:15,highIncome:2;2
+feShare_water_heating_biomod;RC more biomass;5;10;5;5;5;5,Europe:4;1.875;5;15;5,lowIncome:15,highIncome:3;3
+feShare_cooking_natgas;;15;15;5;15;15;45,Europe:46;45;15;65;45,lowIncome:65,highIncome:78;78
+feShare_cooking_elec;EI and RC high, MC close to technical potential;80;85;95;85;80;50,Europe:52;50;80;15;50,lowIncome:15,highIncome:15;15
+feShare_cooking_heat;;0;0;0;0;0;0;0;0;0;0;0
+feShare_cooking_petrol;0 petrol in all of scenarios;5;0;0;0;5;5,Europe:2;5;5;20;5,lowIncome:20,highIncome:2;2
+feShare_cooking_biomod;;0;0;0;0;0;0;0;0;0;0;0
+feShare_appliances_light_elec;;100;100;100;100;100;100;100;100;100;100;100
+feShare_appliances_light_natgas;;0;0;0;0;0;0;0;0;0;0;0
+feShare_appliances_light_biomod;;0;0;0;0;0;0;0;0;0;0;0
+feShare_space_cooling_elec;;100;100;100;100;100;100;100;100;100;100;100
+feShare_space_cooling_natgas;;0;0;0;0;0;0;0;0;0;0;0
+feShare_space_cooling_heat;;0;0;0;0;0;0;0;0;0;0;0
+feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0
+speed;;2200;2200;2200;2200;2200;2300;2100;2200;2400;2400,lowIncome:2500,highIncome:2300;2200
+speed_fullconv;;2070;2070;2070;2070;2070;2070;2070;;2070;2070;2070
+floorspaceCap;;60;75;50;40;NA;NA;40;NA;NA;NA;NA
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;20000;20000;20000;20000;20000;20000;20000
+gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0
+interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/default.csv
+++ b/inst/config/default.csv
@@ -1,9 +1,9 @@
 parameter;parameterComment;history;default
-popScen;population scenario;NA;pop_SSP2
-gdpScen;gdp scenario;NA;gdp_SSP2
-gdppopScen;gdppop scenario;NA;gdppop_SSP2
-urbanisationScen;urbanisation scenario;NA;pop_SSP2
-densityScen;density scenario;NA;density_SSP2
+popScen;population scenario;NA;SSP2
+gdpScen;gdp scenario;NA;SSP2
+gdppopScen;gdppop scenario;NA;SSP2
+urbanisationScen;urbanisation scenario;NA;SSP2
+densityScen;density scenario;NA;SSP2
 floorScen;floorspace scenario;NA;SSP2
 uvalueScen;uvalue scenario;NA;picontrol
 hddcddScen;;NA;SSP2

--- a/man/runEdgeBuildings.Rd
+++ b/man/runEdgeBuildings.Rd
@@ -9,7 +9,7 @@ runEdgeBuildings(
   outputDir = "./output",
   reporting = NULL,
   madratDir = NULL,
-  inputdataRevision = "0.4.2",
+  inputdataRevision = "0.4.4",
   forceDownload = FALSE
 )
 }


### PR DESCRIPTION
- implement change of macro driver scenario names (replaces PR #19), i.e. remove "gdp_", "pop_" prefixes, remove "SSP2EU" scenario. To this end, restructure pop, gdp, gdppop data frames, such that from the start they contain a scenario and a variable column.
- correct bug in makeProjections.
- set default inputdata revision to 0.4.4 (which corresponds to the first data set with new scenario names).