### PR TITLE
Unit shift: USD 2005 -> USD 2017

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '805560'
+ValidationKey: '825699'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.4.0
+version: 0.4.1
 date-released: '2025-02-20'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),

--- a/R/getShareECprojections.R
+++ b/R/getShareECprojections.R
@@ -387,14 +387,13 @@ projectShares <- function(df, var, xTar, yTar, phaseOutMaxEnd, phaseOutStart) {
       # weight (1 is the linear case)
       power <- 1
 
-      # nolint start
       # reach yTar once gdppop reaches threshold
       thresholdPhaseOut <- pmax(
         yTar,
         predEndHist + (yTar - predEndHist) *
           (pmax(0, dataRegScen$gdppop - gdppopEndHist) /
-             (xTar[[reg, "value"]] - gdppopEndHist))^power)
-      # nolint end
+             (xTar[[reg, "value"]] - gdppopEndHist))^power
+      )
 
       # max phase out: reaches 0 when gdppop is 1.5 gdppop(eoh)
       maxPhaseOut <- predEndHist *

--- a/R/runEdgeBuildings.R
+++ b/R/runEdgeBuildings.R
@@ -19,7 +19,7 @@ runEdgeBuildings <- function(config = "configEDGEscens.csv",
                              outputDir = "./output",
                              reporting = NULL,
                              madratDir = NULL,
-                             inputdataRevision = "0.5",
+                             inputdataRevision = "0.5.2",
                              forceDownload = FALSE) {
 
   # TODO: relocate data_internal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.4.0**
+R package **edgebuildings**, version **0.4.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/robinhasse/edgebuildings/workflows/check/badge.svg)](https://github.com/robinhasse/edgebuildings/actions) [![codecov](https://codecov.io/gh/robinhasse/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/robinhasse/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -55,15 +55,16 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.0."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, FÃ¼hrlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector." Version: 0.4.1.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.0},
-  author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector},
+  author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal FÃ¼hrlich},
   date = {2025-02-20},
   year = {2025},
+  note = {Version: 0.4.1},
 }
 ```

--- a/edgebuildings.Rproj
+++ b/edgebuildings.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ce05e73e-a8b7-4299-a096-50e017fb9ac8
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/inst/config/configEDGEscens.csv
+++ b/inst/config/configEDGEscens.csv
@@ -23,12 +23,12 @@ econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to 
 econCoef_biotrad;;2;1;0.25;1,lowIncome:0.25,highIncome:1.5;1.5
 econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
 econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.5,Europe:0.75;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.1266311,Europe:-10;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.67122;-10.33475,Europe:-10.20812;-10.03205;-10.33475,lowIncome:-9.823925;-10.67122
 econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;5;3.875;5,lowIncome:3.875;8
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_space_cooling.elec_X_lrc;;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707
 econCoef_water_heating.elecHP_eff_X_Asym;;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
 econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
 feShare_space_heating_natgas;;15;35,Europe:32;40;35,lowIncome:40,highIncome:75;75
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40,Europe:37;15;40,lowIncome:15,highIncome:17;17
@@ -55,6 +55,6 @@ feShare_space_cooling_biomod;;0;0;0;0;0
 speed;;2200;2300;2400;2400,lowIncome:2500,highIncome:2300;2200
 speed_fullconv;;2070;2070;2070;2070;2070
 floorspaceCap;;NA;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;30000;30000;30000;30000;30000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;36941;36941;36941;36941;36941
 gdpBoost;;0;0;0;0;0
 interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/configFull.csv
+++ b/inst/config/configFull.csv
@@ -23,11 +23,11 @@ econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1;1
 econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.35;0.7;0.35;0.85;0.75,lowIncome:0.85;0.75;0.75;0.7
 econCoef_biotrad;;2;2;2;2;2;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5;1.5;1
 econCoef_space_heating.elec_X_Asym;RC a little less efficient, MC more efficient;4.2;4.2;5.5;4;4.2;3,Europe:4;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3,Europe:4
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334;-10.46310334;-10.1266311,Europe:-10
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.67122;-10.67122;-10.67122;-10.67122;-10.67122;-10.33475,Europe:-10.20812;-10.33475;-9.823925;-10.33475,lowIncome:-9.823925;-10.67122;-10.67122;-10.33475,Europe:-10.20812
 econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;5;3.875;5,lowIncome:3.875;8;8;5
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
+econCoef_space_cooling.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707;-10.51707;-10.51707
 econCoef_water_heating.elec_X_Asym;;4.2;4.2;5.5;4;4.2;3;3;1.71875;2.6,lowIncome:1.71875,highIncome:3.4;4.75;4.75;3
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266;-10.30895266;-10.30895266
+econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707;-10.51707;-10.51707
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9;0.9;0.9
 feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;15;40;35,lowIncome:40,highIncome:75;75;75;35,Europe:32
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;40;15;40,lowIncome:15,highIncome:17;17;17;40,Europe:37
@@ -54,6 +54,6 @@ feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0;0
 speed;;2200;2200;2200;2200;2200;2300;2200;2400;2400,lowIncome:2500,highIncome:2300;2200;2200;2300
 speed_fullconv;;2070;2070;2070;2070;2070;2070;;2070;2070;2070;2070;2070
 floorspaceCap;;60;75;50;40;NA;NA;NA;NA;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;30000;30000;30000;30000;30000;30000;30000;30000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;12314;14777;13545;12314;36941;36941;36941;36941;36941;36941;36941;36941
 gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0;0
 interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/configSSP2-Impact.csv
+++ b/inst/config/configSSP2-Impact.csv
@@ -24,11 +24,11 @@ econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1
 econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.7;0.7;0.7;0.7;0.7;0.7
 econCoef_biotrad;;1;1;1;1;1;1
 econCoef_space_heating.elec_X_Asym;RC a little less efficient, MC more efficient;3,Europe:4;3,Europe:4;3,Europe:4;3,Europe:4;3,Europe:4;3,Europe:4
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311,Europe:-10
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812
 econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;5;5;5;5;5;5
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266
+econCoef_space_cooling.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707
 econCoef_water_heating.elec_X_Asym;;3;3;3;3;3;3
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266
+econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9
 feShare_space_heating_natgas;;35,Europe:32;35,Europe:32;35,Europe:32;35,Europe:32;35,Europe:32;35,Europe:32
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40,Europe:37;40,Europe:37;40,Europe:37;40,Europe:37;40,Europe:37;40,Europe:37
@@ -55,6 +55,6 @@ feShare_space_cooling_biomod;;0;0;0;0;0;0
 speed;;2300;2300;2300;2300;2300;2300
 speed_fullconv;;2070;2070;2070;2070;2070;2070
 floorspaceCap;;NA;NA;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;30000;30000;30000;30000;30000;30000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;36941;36941;36941;36941;36941;36941
 gdpBoost;;0;0;0;0;0;0
 interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/configTest.csv
+++ b/inst/config/configTest.csv
@@ -23,11 +23,11 @@ econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1
 econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.75;0.7
 econCoef_biotrad;;1.5;1
 econCoef_space_heating.elec_X_Asym;RC a little less efficient, MC more efficient;4.75;3,Europe:4
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.1266311,Europe:-10
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.67122;-10.33475,Europe:-10.20812
 econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;5
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266
+econCoef_space_cooling.elec_X_lrc;;-10.51707;-10.51707
 econCoef_water_heating.elec_X_Asym;;4.75;3
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266
+econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9
 feShare_space_heating_natgas;;75;35,Europe:32
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;17;40,Europe:37
@@ -54,6 +54,6 @@ feShare_space_cooling_biomod;;0;0
 speed;;2200;2300
 speed_fullconv;;2070;2070
 floorspaceCap;;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;30000;30000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;36941;36941
 gdpBoost;;0;0
 interpolate;;TRUE;TRUE

--- a/inst/config/config_remind.csv
+++ b/inst/config/config_remind.csv
@@ -23,12 +23,12 @@ econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to 
 econCoef_biotrad;;2;2;2;2;2;1;1;2;0.25;1,lowIncome:0.25,highIncome:1.5;1.5
 econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;5;6;5;5;5;6;5;3.875;5,lowIncome:3.875,highIncome:5;6
 econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.8;0.9;0.75;0.8;0.5,Europe:0.75;0.5,Europe:0.75;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.46310334;-10.1266311,Europe:-10;-10.1266311,Europe:-10;-10.1266311;-9.61580548;-10.1266311,lowIncome:-9.61580548;-10.46310334
+econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.67122;-10.67122;-10.67122;-10.67122;-10.67122;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475;-9.823925;-10.33475,lowIncome:-9.823925;-10.67122
 econCoef_space_cooling.elec_X_Asym;RC a little less efficient, MC more efficient;8;8;10;7;8;5;6.5;5;3.875;5,lowIncome:3.875;8
-econCoef_space_cooling.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_space_cooling.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707
 econCoef_water_heating.elecHP_eff_X_Asym;;5;5;6;5;5;5;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
 econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.8;0.9;0.75;0.8;0.5;0.5;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
-econCoef_water_heating.elec_X_lrc;;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.30895266;-10.1266311;-10.30895266,lowIncome:-10.1266311;-10.30895266
+econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707
 econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
 feShare_space_heating_natgas;;15;15;5;15;15;35,Europe:32;15;15;40;35,lowIncome:40,highIncome:75;75
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;40;40,Europe:37;75;40;15;40,lowIncome:15,highIncome:17;17
@@ -55,6 +55,6 @@ feShare_space_cooling_biomod;;0;0;0;0;0;0;0;0;0;0;0
 speed;;2200;2200;2200;2200;2200;2300;2100;2200;2400;2400,lowIncome:2500,highIncome:2300;2200
 speed_fullconv;;2070;2070;2070;2070;2070;2070;2070;;2070;2070;2070
 floorspaceCap;;60;75;50;40;NA;NA;40;NA;NA;NA;NA
-incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;10000;12000;11000;10000;20000;20000;20000;20000;20000;20000;20000
+incomeThresholdEC;account for lower GDP/cap in RC and tighter regulation in MC;12314;14777;13545;12314;24628;24628;24628;24628;24628;24628;24628
 gdpBoost;;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0,lowIncome:0.35,mediumIncome:0.2;0;0;0;0;0;0;0
 interpolate;;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE;TRUE

--- a/inst/config/default.csv
+++ b/inst/config/default.csv
@@ -25,12 +25,12 @@ econCoef_uvalues_X_min;minimal U value in W/m2.K?;1;0.7
 econCoef_biotrad;elasticity correction factor for traditional biomass use?;1;1
 econCoef_space_heating.elecHP_eff_X_Asym;maximal FE-UE efficiency of space heating with heat pumps;1;5
 econCoef_space_heating.elecHP_share_X_Asym;maximal share of heat pumps in space heating with electricity;1;0.5
-econCoef_space_heating.elec_X_lrc;rate parameter of FE-UE efficiency of space heating with electricity;1;-10.1266311
+econCoef_space_heating.elec_X_lrc;rate parameter of FE-UE efficiency of space heating with electricity;1;-10.33475
 econCoef_space_cooling.elec_X_Asym;maximal FE-UE efficiency of space cooling with electricity;1;5
-econCoef_space_cooling.elec_X_lrc;rate parameter of FE-UE efficiency of space cooling with electricity;1;-10.30895266
+econCoef_space_cooling.elec_X_lrc;rate parameter of FE-UE efficiency of space cooling with electricity;1;-10.51707
 econCoef_water_heating.elecHP_eff_X_Asym;maximal FE-UE efficiency of water heating with heat pumps;1;5
 econCoef_water_heating.elecHP_share_X_Asym;maximal share of heat pumps in water heating with electricity;1;0.5
-econCoef_water_heating.elec_X_lrc;rate parameter of FE-UE efficiency of water heating with electricity;1;-10.30895266
+econCoef_water_heating.elec_X_lrc;rate parameter of FE-UE efficiency of water heating with electricity;1;-10.51707
 econCoef_appliances_light.elec_X_Asym;maximal FE-UE efficiency of appliances and lighting with electricity;1;0.9
 feShare_space_heating_natgas;FE share of natural gas in space heating in percent;NA;35
 feShare_space_heating_elec;FE share of electricity in space heating in percent;NA;40
@@ -57,7 +57,9 @@ feShare_space_cooling_biomod;FE share of modern biomass in space cooling in perc
 speed;year in which long-term target values are reached;NA;2300
 speed_fullconv;year in which mid-term target values are reached;NA;2070
 floorspaceCap;cap on floorspace per capita in m2;NA;NULL
-incomeThresholdEC;income threshold above which low-affluence energy carrier end use combiations are phased out in USD/cap;NA;20000
+incomeThresholdEC;income threshold above which low-affluence energy carrier end use combiations are phased out in USD2017/cap;NA;24628
+incomeThresholdUvalue;between zero and this threshold in USD2017/cap, the factor between global U-values estimates and local values decrease from multiUValue to one;NA;24628
+multiUValue;multiple of the global Uvalue estimate that is assumed for low-income regions;NA;1.5
 gdpBoost;artificial GDP boost to push advancement;0;0
 UvalHCDfix;fix the heating and cooling degree day assumptions in the calculation of U value projections;NA;FALSE
 interpolate;?;TRUE;TRUE

--- a/inst/data_internal/mappings/correctEfficiencies.csv
+++ b/inst/data_internal/mappings/correctEfficiencies.csv
@@ -1,4 +1,4 @@
 variable;Asym;R0;lrc;phi3
-space_cooling.elec;3.10;0.50;-10.12663;NA
+space_cooling.elec;3.10;0.50;-10.3348;NA
 water_heating.elec;1.5;NA;NA;NA
 space_heating.elec;1.5;NA;NA;NA

--- a/man/getUvalues.Rd
+++ b/man/getUvalues.Rd
@@ -50,7 +50,8 @@ As an estimation model we assume an exponential relation between the sum of
 annual degree days (HDD/CDD) and the U-value. As the wished level of
 insulation might be unaffordable for low-income households/businesses, we multiply
 the U-value computed by the previous equation by a coefficient decreasing from
-two to one when the per capita income of the region considered moves from US$0 to US$15000.
+a given multiple to one when the per capita income of the region considered
+moves from zero to a given threshold.
 }
 \author{
 Antoine Levesque, Hagen Tockhorn


### PR DESCRIPTION
Shifting the GDP unit from USD2005 to USD2017. This new EDGE-B version requires new input data that has seen the unit shift in [#50](https://github.com/pik-piam/mredgebuildings/pull/50) of mredgebuildings.

# Changes

In EDGE-B, the following changes have been made:
- adapt income thresholds
  - phase out of low-ladder carrier/end use ombinations: `incomeThresholdEC`
  - U-value improvement: `incomeThresholdUvalue`
- Where we use asymptotic models $f(I) = Asym + (R0 - Asym) \cdot \exp(-\exp(lrc) \cdot I)$ with fixed coefficients, I adapted the GDP/cap coefficient: $f(I_\text{2005}) \stackrel{!}{=} f(I_\text{2017}) \implies lrc_\text{2017} = lrc_\text{2005} - \ln \left( \dfrac{I_\text{2017}}{I_\text{2005}} \right) = lrc_\text{2005} - 0.20812$

In this course, I also introduced another new switches to make formerly hard-coded coefficients in the U-value calculation variable and transparent: `multiUValue`

# Expected changes

The unit shift should now be nothing more than a constant multiplication of gdp: $\dfrac{I_\text{2017}}{I_\text{2005}} = 1.2314$. At this point, there should be no inter-regional shifts anymore as `mrdirvers` has already switched to the new units already and has only augmented 2005 unit by constant multiplication. We therefore expect identical results. The inter-regional shifts already entered the model when mrdrivers was switched to the new units even though we nominally got old units.

# Validation

- [x] floor space identical
- [x] UE end use demand identical
- [x] FE carrier demand identical