### PR TITLE
Clean startyear shift for EC phaseout shares

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '908370'
+ValidationKey: '929844'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.4.5
-date-released: '2025-04-08'
+version: 0.4.6
+date-released: '2025-05-06'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.4.5
+Version: 0.4.6
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -62,5 +62,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2025-04-08
+Date: 2025-05-06
 VignetteBuilder: knitr

--- a/R/getShareECprojections.R
+++ b/R/getShareECprojections.R
@@ -16,6 +16,7 @@
 #' @param gdp data.frame gdp data
 #' @param gdppop data.frame gdp per capita
 #' @param scenAssumpFEShares data.frame scenario-specific FE sare assumptions
+#' @param refIncomeThresholdEC data frame with reference income threshold for phaseout
 #' @param regionalmap data.frame regional mapping
 #'
 #' @returns data.frame
@@ -51,6 +52,7 @@ getShareECprojections <- function(config,
                                   gdp,
                                   gdppop,
                                   scenAssumpFEShares,
+                                  refIncomeThresholdEC,
                                   regionalmap) {
   # FUNCTIONS ------------------------------------------------------------------
 
@@ -214,12 +216,20 @@ getShareECprojections <- function(config,
   for (useCarrier in useCarrierPhaseOut) {
     fePhaseOut <- projectShares(df = fePhaseOut,
                                 var = useCarrier,
-                                xTar = incomeThresholdEC,
+                                xTar = refIncomeThresholdEC,
                                 yTar = 0.01,
                                 phaseOutMaxEnd = feShareSpeed,
                                 phaseOutStart = endOfData)
   }
-
+  fePhaseOut <- filter(fePhaseOut, .data[["period"]] <= endOfHistory | .data[["variable"]] %in% c("gdp", "gdppop"))
+  for (useCarrier in useCarrierPhaseOut) {
+    fePhaseOut <- projectShares(df = fePhaseOut,
+                                var = useCarrier,
+                                xTar = incomeThresholdEC,
+                                yTar = 0.01,
+                                phaseOutMaxEnd = feShareSpeed,
+                                phaseOutStart = endOfHistory)
+  }
 
   # save the projectShares and split the variable columns
   fePhaseOut <- fePhaseOut %>%

--- a/R/visualiseScenarios.R
+++ b/R/visualiseScenarios.R
@@ -82,7 +82,7 @@ visualiseScenarios <- function(path, outputFile = NULL) {
   eurRegions <- mapping %>%
     filter(.data[["RegionCode"]] == "EUR") %>%
     getElement("RegionCodeEUR")
-  
+
   plottedRegions <- mapping %>%
     select("RegionCode") %>%
     unique() %>%
@@ -440,10 +440,18 @@ visualiseScenarios <- function(path, outputFile = NULL) {
 
   ## carrier efficiency and shares ====
 
-  # Only generate these plots if only one path is given
-  if (length(linetypeScale) == 1) {
+  # Only generate these plots if only one path or only one scenario is given
+  if (length(linetypeScale) == 1 || length(unique(data$scenario)) == 1) {
 
     bookmarks <- .addBookmark(bookmarks, "Carrier projections", i, 1)
+
+    if (length(linetypeScale) == 1) {
+      linetypeCarrier <- "scenario"
+      linetypeScaleCarrier <- setNames(seq_along(unique(pData$scenario)), unique(pData$scenario))
+    } else {
+      linetypeCarrier <- "version"
+      linetypeScaleCarrier <- linetypeScale
+    }
 
     for (projType in c("efficiency", "share")) {
 
@@ -462,8 +470,8 @@ visualiseScenarios <- function(path, outputFile = NULL) {
       linePlots(pData,
                 title = paste("Carrier", projType, "by end use"),
                 yAxisLabel = "",
-                linetype = "scenario",
-                linetypeScale = setNames(seq_along(unique(pData$scenario)), unique(pData$scenario)),
+                linetype = linetypeCarrier,
+                linetypeScale = linetypeScaleCarrier,
                 color = "carrier",
                 colorScale = colorScale[["Carrier"]],
                 facet = "enduse")
@@ -624,6 +632,7 @@ visualiseScenarios <- function(path, outputFile = NULL) {
           title = switch(x, period = paste(eu, toupper(enType), "demand per capita")),
           xAxisLabel = x,
           yAxisLabel = switch(x, period = "GJ/yr/cap"),
+          linetypeScale = linetypeScale,
           color = "region",
           facet = "scenario",
           x = x,
@@ -661,6 +670,7 @@ visualiseScenarios <- function(path, outputFile = NULL) {
           title = switch(x, period = paste(c, toupper(enType), "demand per capita")),
           xAxisLabel = x,
           yAxisLabel = switch(x, period = "GJ/yr/cap"),
+          linetypeScale = linetypeScale,
           color = "region",
           facet = "scenario",
           x = x,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.4.5**
+R package **edgebuildings**, version **0.4.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.5."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2025). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.6."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.5},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.4.6},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
-  date = {2025-04-08},
+  date = {2025-05-06},
   year = {2025},
 }
 ```

--- a/inst/_targets.R
+++ b/inst/_targets.R
@@ -220,6 +220,16 @@ list(
     read.csv(correctEfficiencies.csv, stringsAsFactors = FALSE)
   ),
 
+  # reference EC income threshold for phase-out
+  tar_target(
+    refIncomeThresholdEC,
+    config["SSP2", "incomeThresholdEC"] %>%
+      as.numeric() %>%
+      buildScenInput(subtype = "mapping",
+                     regionmap = regionmap,
+                     valueOnly = TRUE)
+  ),
+
 
   # Process Files---------------------------------------------------------------
 
@@ -498,6 +508,7 @@ list(
                             gdp = gdp,
                             gdppop = gdppop,
                             scenAssumpFEShares = scenAssumpFEshares,
+                            refIncomeThresholdEC = refIncomeThresholdEC,
                             regionalmap = regionmap)
     },
     pattern = map(config),

--- a/man/getShareECprojections.Rd
+++ b/man/getShareECprojections.Rd
@@ -11,6 +11,7 @@ getShareECprojections(
   gdp,
   gdppop,
   scenAssumpFEShares,
+  refIncomeThresholdEC,
   regionalmap
 )
 }
@@ -26,6 +27,8 @@ getShareECprojections(
 \item{gdppop}{data.frame gdp per capita}
 
 \item{scenAssumpFEShares}{data.frame scenario-specific FE sare assumptions}
+
+\item{refIncomeThresholdEC}{data frame with reference income threshold for phaseout}
 
 \item{regionalmap}{data.frame regional mapping}
 }


### PR DESCRIPTION
This PR modifies the projection of carrier shares for phase-out enduse-carrier combinations:
- The share computation until 2025 inclusively is based on the SSP2 income threshold.
- Only afterwards the scenario-specific threshold is applied.
Additionally, the visualization of carrier shares and efficiency is extended
- Plots for carrier shares and efficiency are now also available in the case that several paths are given, but only one scenario
- a bug in the visualization function was fixed

The modification of the projection is only relevant for SSP1 and SDP scenarios. In those scenarios,  the decline of phase-out enduse-carrier combinations now happens a bit later and a bit faster, but changes are small. Changes are most pronounced for IND and similarly for OAS (not shown).

<img width="542" alt="EC_share_IND" src="https://github.com/user-attachments/assets/6f29267f-d576-4a7b-a856-4cea057b536a" />

<img width="542" alt="FE_by_carrier_IND" src="https://github.com/user-attachments/assets/3707f6f8-5b65-4b63-aaee-b8ff5acc1fc0" />

<img width="545" alt="FE_by_carrier_GLO" src="https://github.com/user-attachments/assets/28bfad3e-1173-43a4-b029-5c8d4db0bfa7" />
