### PR TITLE
fix bug in readConfig scenario handling

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1067976'
+ValidationKey: '1088726'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.5.2
-date-released: '2026-03-26'
+version: 0.5.3
+date-released: '2026-03-30'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -64,5 +64,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2026-03-26
+Date: 2026-03-30
 VignetteBuilder: knitr

--- a/R/readConfig.R
+++ b/R/readConfig.R
@@ -228,16 +228,10 @@ readConfig <- function(config = getSystemFile("config", "configTest.csv", packag
 
   # parameters with regional values are filled with data frames that contain
   # the value for each region
-  configList <- mapply(regionalValues, fullConfig[scenNames, ], # nolint
-                 defaultValues, SIMPLIFY = FALSE)
-  # When there's only one scenario, assign each column individually to preserve list-columns
-  if (length(scenNames) == 1) {
-    for (i in seq_along(configList)) {
-      fullConfig[scenNames, i] <- list(configList[[i]])
-    }
-  } else {
-    fullConfig[scenNames, ] <- configList %>%
-      as.data.frame()
+  for (scen in scenNames) {
+    fullConfig[scen, ] <- Map(regionalValues,
+                              fullConfig[scen, ],
+                              defaultValues)
   }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.5.2**
+R package **edgebuildings**, version **0.5.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/hagento/edgebuildings/workflows/check/badge.svg)](https://github.com/hagento/edgebuildings/actions) [![codecov](https://codecov.io/gh/hagento/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/hagento/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.5.2."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.5.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.5.2},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.5.3},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
-  date = {2026-03-26},
+  date = {2026-03-30},
   year = {2026},
 }
 ```

--- a/man/runEdgeBuildings.Rd
+++ b/man/runEdgeBuildings.Rd
@@ -30,7 +30,10 @@ name of an internal config file.}
 
 \item{scenario}{character vector, subset of scenarios to run. If NULL (default),
 all scenarios in the config file will be run. Scenario names correspond to
-column names in the config file (e.g., c("SSP2", "SSP5")).}
+column names in the config file (e.g., c("SSP2", "SSP5")). Note: SSP2 is
+always required and will be automatically included if not specified, as it
+provides reference values and is used for carrier share extension between
+historic data and scenario start.}
 }
 \description{
 Run EDGE-Buildings


### PR DESCRIPTION
In PR #45 I accidentally introduced a bug in the scenario handling that I overlooked while testing. 

When processing multiple scenarios, `readConfig.R` incorrectly used `as.data.frame()` to assign the `mapply` output, causing config values to shift between scenarios. This resulted in scenarios receiving parameter values from other scenarios (e.g., SSP1 would get SSP2's GDP scenario name, SSP1 would get SSP2's GDP boost value, etc.), leading to validation errors and incorrect model configurations. We now process each scenario individually using the same assignment logic, ensuring config values remain properly aligned with their respective scenarios.

I also updated the `runEdgeBuildings` header to include that `SSP2` is always added if not specified and available in the scenario config. 