### PR TITLE
re-add speed_uvalue to default config

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1438570'
+ValidationKey: '1460115'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.7.0
-date-released: '2026-04-08'
+version: 0.7.1
+date-released: '2026-04-22'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.7.0
+Version: 0.7.1
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -64,5 +64,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2026-04-08
+Date: 2026-04-22
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.7.0**
+R package **edgebuildings**, version **0.7.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgebuildings)](https://cran.r-project.org/package=edgebuildings) [![R build status](https://github.com/hagento/edgebuildings/workflows/check/badge.svg)](https://github.com/hagento/edgebuildings/actions) [![codecov](https://codecov.io/gh/hagento/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/hagento/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.0."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.1."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.0},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.1},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
-  date = {2026-04-08},
+  date = {2026-04-22},
   year = {2026},
 }
 ```

--- a/inst/config/default.csv
+++ b/inst/config/default.csv
@@ -67,6 +67,7 @@ UvalHCDfix;fix the heating and cooling degree day assumptions in the calculation
 interpolate;?;TRUE;TRUE
 speed_feShare;year in which long-term target values are reached;NA;2150
 speed_feShare_ariadneFix;year in which long-term target values are reached;NA;2100
+speed_uvalue;year in which long-term uvalue target values are reached;;NULL
 ariadneFix;?;NA;FALSE
 periodBegin;lower temporal boundary;NA;1990
 endOfHistory;lower temporal boundary of scenario data;NA;2025


### PR DESCRIPTION
Due to a rebase and subsequent force push and merge of PR #40, I accidentally removed `speed_uvalue` from the default config, resulting in an error message when running the model. 