### PR TITLE
Adjust good performance policy scenario

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1483200'
+ValidationKey: '1503873'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'edgebuildings: Model for the projection of global energy demand in the buildings
   sector'
-version: 0.7.2
-date-released: '2026-05-27'
+version: 0.7.3
+date-released: '2026-05-28'
 abstract: 'The Energy Demand GEnerator projects energy demand for buildings both at
   the useful and final energy level. It covers the global demand and five energy services:
   space heating, space cooling, appliances and lighting (treated together) water heating

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgebuildings
 Title: Model for the projection of global energy demand in the buildings sector
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: c(
   person(given = "Antoine", family = "Levesque",
          role = c("aut")),
@@ -64,5 +64,5 @@ Suggests:
   rmarkdown,
   rprojroot,
   xmpdf
-Date: 2026-05-27
+Date: 2026-05-28
 VignetteBuilder: knitr

--- a/R/buildingsProjections.R
+++ b/R/buildingsProjections.R
@@ -477,6 +477,9 @@ buildingsProjections <- function(config,
     !(grepl("^SSP.*", .data[["scenario"]]) & .data[["period"]] <= endOfHistory)
   )
 
+  # Add efficiency and energy carrier shares to output data frame
+  df <- rbind(df, prepareForOutput(feueEff, "efficiency"), prepareForOutput(feSharesEC, "share"))
+
 
   #--- Split electric space_heating
 
@@ -486,7 +489,6 @@ buildingsProjections <- function(config,
       c("space_heating", "water_heating"),
       splitElec,
       df = df,
-      feueEff = feueEff,
       scenAssump = scenAssump,
       endOfHistory = endOfHistory
     ))
@@ -504,9 +506,6 @@ buildingsProjections <- function(config,
       "elecRH|ue" = grep("elecRH\\|ue", getVars(df), value = TRUE)
     ))
   }
-
-  # Add efficiency and energy carrier shares to output data frame
-  df <- rbind(df, prepareForOutput(feueEff, "efficiency"), prepareForOutput(feSharesEC, "share"))
 
 
   #--- Add RCP scenario to scenario name if existent
@@ -647,7 +646,6 @@ addEURagg <- function(df, extVars, intVars, floorVars, regionmap) {
 #' Split heat pump and resistive electric fe and ue
 #'
 #' @param df data frame containing share and efficiency data
-#' @param feueEff historical and future FE->UE conversion efficiencies
 #' @param enduseChar character, enduse for which electric FE demand should be split
 #' @param scenAssump carrier/enduse-specific scenario assumptions
 #' @param endOfHistory Last historic time period
@@ -659,7 +657,7 @@ addEURagg <- function(df, extVars, intVars, floorVars, regionmap) {
 #' @importFrom quitte calc_addVariable_
 #' @importFrom tidyr gather spread
 #'
-splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
+splitElec <- function(df, enduseChar, scenAssump, endOfHistory) {
   effRHasym  <- 1.0 # assumed by AL but IDEES finds rather 0.8 - 0.9
 
   hpEffHist <- 3
@@ -668,10 +666,6 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
   expAsym <- function(valStart, valAsym, t, tStart, tau = 50) {
     valStart + (valAsym - valStart) * (1 - exp(-pmax(0, t - tStart) / tau))
   }
-
-  effElec <- feueEff %>%
-    filter(.data[["enduse"]] == enduseChar, .data[["carrier"]] == "elec") %>%
-    select(-"enduse", -"carrier")
 
   scenAssumpHP <- expand.grid(region = unique(df[["region"]])) %>%
     mutate(scenario = "history") %>%
@@ -682,12 +676,13 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
               by = c("region", "scenario", paste0(enduseChar, ".elecHP_eff_X_Asym")))
 
   hp <- df %>%
-    filter(grepl(paste0(enduseChar, "\\.elec\\|(ue|fe)"), .data[["variable"]]),
-           .data[["region"]] != "GLO") %>%
+    filter(grepl(paste0(enduseChar, "\\.elec\\|(ue|fe|share|efficiency)"), .data[["variable"]]),
+           .data[["region"]] != "GLO",
+           .data$period >= 1990) %>%
+    mutate(variable = sub(paste0("^", enduseChar, "\\."), "", .data$variable)) %>%
     spread("variable", "value") %>%
-    left_join(effElec, by = c("scenario", "region", "period")) %>%
     group_by(across("region")) %>%
-    mutate(effRHstart = min(min(.data[["efficiency"]]), effRHasym)) %>%
+    mutate(effRHstart = min(min(.data[["elec|efficiency"]]), effRHasym)) %>%
     ungroup() %>%
     left_join(scenAssumpHP, by = c("scenario", "region")) %>%
     mutate(
@@ -696,12 +691,12 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
                            .data[["period"]],
                            endOfHistory,
                            tau = 25),
-                   .data[["efficiency"]]),
+                   .data[["elec|efficiency"]]),
       effHP = expAsym(hpEffHist,
                       .data[[paste0(enduseChar, ".elecHP_eff_X_Asym")]],
                       .data[["period"]],
                       endOfHistory),
-      shareHP = (.data[["efficiency"]] - .data[["effRH"]]) /
+      shareHP = (.data[["elec|efficiency"]] - .data[["effRH"]]) /
         (.data[["effHP"]] - .data[["effRH"]])
     ) %>%
     group_by(across("region")) %>%
@@ -717,7 +712,7 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
                        .data[["shareHP"]]),
       factor = ifelse(
         .data[["shareHP"]] != 0,
-        (.data[["efficiency"]] - .data[["effRH"]]) /
+        (.data[["elec|efficiency"]] - .data[["effRH"]]) /
           ((.data[["effHP"]] - .data[["effRH"]]) * .data[["shareHP"]]),
         1
       ),
@@ -726,20 +721,29 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
       shareHP = sqrt(.data[["factor"]]) * .data[["shareHP"]]
     ) %>%
     gather("variable", "value", -"model", -"scenario", -"period", -"region", -"unit")
+
   hp <- hp %>%
     calc_addVariable_(
       stats::setNames(
         list(
-          paste0("`", enduseChar, ".elec|fe` * shareHP"),
-          paste0("`", enduseChar, ".elec|fe` * (1 - shareHP)"),
+          "`elec|fe` * shareHP",
+          "`elec|fe` * (1 - shareHP)",
           paste0("`", enduseChar, ".elecHP|fe` * effHP"),
-          paste0("`", enduseChar, ".elecRH|fe` * effRH")
+          paste0("`", enduseChar, ".elecRH|fe` * effRH"),
+          "`elec|share` * shareHP",
+          "`elec|share` * (1 - shareHP)",
+          "effHP",
+          "effRH"
         ),
         c(
           paste0("`", enduseChar, ".elecHP|fe`"),
           paste0("`", enduseChar, ".elecRH|fe`"),
           paste0("`", enduseChar, ".elecHP|ue`"),
-          paste0("`", enduseChar, ".elecRH|ue`")
+          paste0("`", enduseChar, ".elecRH|ue`"),
+          paste0("`", enduseChar, ".elecHP|share`"),
+          paste0("`", enduseChar, ".elecRH|share`"),
+          paste0("`", enduseChar, ".elecHP|efficiency`"),
+          paste0("`", enduseChar, ".elecRH|efficiency`")
         )
       ),
       only.new = TRUE
@@ -748,8 +752,9 @@ splitElec <- function(df, feueEff, enduseChar, scenAssump, endOfHistory) {
   # compute global sum
   hp %>%
     group_by(across(c("model", "scenario", "period", "variable", "unit"))) %>%
-    reframe(
-      value = sum(.data[["value"]]),
+    summarise(
+      value = ifelse(grepl("\\|(ue|fe)$", unique(.data$variable)), sum(.data[["value"]]), mean(.data$value)),
+      # value = sum(.data[["value"]]),
       region = "GLO"
     ) %>%
     rbind(hp)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Model for the projection of global energy demand in the buildings sector
 
-R package **edgebuildings**, version **0.7.2**
+R package **edgebuildings**, version **0.7.3**
 
    [![R build status](https://github.com/ricardarosemann/edgebuildings/workflows/check/badge.svg)](https://github.com/ricardarosemann/edgebuildings/actions) [![codecov](https://codecov.io/gh/ricardarosemann/edgebuildings/branch/master/graph/badge.svg)](https://app.codecov.io/gh/ricardarosemann/edgebuildings) [![r-universe](https://pik-piam.r-universe.dev/badges/edgebuildings)](https://pik-piam.r-universe.dev/builds)
 
@@ -55,15 +55,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **edgebuildings** in publications use:
 
-Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.2."
+Levesque A, Hasse R, Tockhorn H, Rosemann R, Führlich P (2026). "edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.2},
+  title = {edgebuildings: Model for the projection of global energy demand in the buildings sector - Version 0.7.3},
   author = {Antoine Levesque and Robin Hasse and Hagen Tockhorn and Ricarda Rosemann and Pascal Führlich},
-  date = {2026-05-27},
+  date = {2026-05-28},
   year = {2026},
 }
 ```

--- a/inst/config/config_archive/config_remind_GP.csv
+++ b/inst/config/config_archive/config_remind_GP.csv
@@ -19,16 +19,16 @@ econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC st
 econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;1;1
 econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.6;0.6
 econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1
-econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.7;0.7,highIncome:0.5
+econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.7;0.7
 econCoef_biotrad;;1;1
 econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;6
-econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.5,Europe:0.75;0.5,highIncome:0.8
+econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.5,Europe:0.75;0.5,highIncome:0.95
 econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812
-econCoef_space_cooling.elec_X_max;;7;8
+econCoef_space_cooling.elec_X_max;;7;7
 econCoef_water_heating.elecHP_eff_X_Asym;;5;5
 econCoef_water_heating.elecHP_share_X_Asym;;0.5;0.5
 econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707
-econCoef_appliances_light.elec_X_Asym;;0.9;0.9,highIncome:0.95
+econCoef_appliances_light.elec_X_Asym;;0.9;0.9
 feShare_space_heating_natgas;;35,Europe:32;35,highIncome:15
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40,Europe:37;40,highIncome:75
 feShare_space_heating_heat;;15,Europe:25;15,highIncome:6.25

--- a/inst/config/config_remind.csv
+++ b/inst/config/config_remind.csv
@@ -20,16 +20,16 @@ econCoef_appliances_light_elas_FACTOR;RC people are happy with less light, MC st
 econCoef_cooking_pop_X_(Intercept);not sure what the does but same logic as above;0.7;0.7;0.6;0.5;0.9;1;1;0.7;1;1;1.25;1;1.3
 econCoef_water_heating_pop_X_Asym;not sure what the does but same logic as above;0.2;0.2;0.15;0.05;0.5;0.6;0.6;0.3;0.6;0.6;1;1,highIncome:1.3;1.3
 econCoef_space_cooling_m2_CDD_Uval_X_Asym;;1;1;1;1;1;1;1;1;1;1;1;1;1
-econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.65;0.7;0.4;0.35;0.7,highIncome:0.5;0.7;0.85;0.75,lowIncome:0.85;0.75
+econCoef_uvalues_X_min;RC less good insulation, MC strong regulation leading to higher insulation;0.25;0.25;0.15;0.35;0.65;0.7;0.4;0.35;0.7;0.7;0.85;0.75,lowIncome:0.85;0.75
 econCoef_biotrad;;2;2;2;2;2;1;1;2;1;1;0.25;1,lowIncome:0.25,highIncome:1.5;1.5
 econCoef_space_heating.elecHP_eff_X_Asym;RC a little less efficient, MC more efficient;5;5;6;5;6;5;6;5;6;5;3.875;5,lowIncome:3.875,highIncome:5;6
-econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.8;0.9;0.75;0.9;0.5,Europe:0.75;0.5,Europe:0.75;0.5;0.5,highIncome:0.8;0.5,Europe:0.75;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
+econCoef_space_heating.elecHP_share_X_Asym;RC a little less efficient, MC more efficient;0.8;0.8;0.9;0.75;0.9;0.5,Europe:0.75;0.5,Europe:0.75;0.5;0.5,highIncome:0.95;0.5,Europe:0.75;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
 econCoef_space_heating.elec_X_lrc;RC a little less efficient, MC more efficient;-10.67122;-10.67122;-10.67122;-10.67122;-10.67122;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-10.33475;-10.33475,Europe:-10.20812;-10.33475,Europe:-10.20812;-9.823925;-10.33475,lowIncome:-9.823925;-10.67122
-econCoef_space_cooling.elec_X_max;;9;9;9;9;9;7;8;7;8;7;6;7,lowIncome:6;9
+econCoef_space_cooling.elec_X_max;;9;9;9;9;9;7;8;7;7;7;6;7,lowIncome:6;9
 econCoef_water_heating.elecHP_eff_X_Asym;;5;5;6;5;6;5;5;5;5;5;3.875;5,lowIncome:3.875,highIncome:5;6
 econCoef_water_heating.elecHP_share_X_Asym;;0.8;0.8;0.9;0.75;0.6;0.5;0.5;0.5;0.5;0.5;0.25;0.4,lowIncome:0.25,highIncome:0.6;0.75
 econCoef_water_heating.elec_X_lrc;;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.51707;-10.33475;-10.51707,lowIncome:-10.33475;-10.51707
-econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9,highIncome:0.95;0.9;0.75;0.82,lowIncome:0.75;0.9
+econCoef_appliances_light.elec_X_Asym;;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.9;0.75;0.82,lowIncome:0.75;0.9
 feShare_space_heating_natgas;;15;15;5;15;5;35,Europe:32;15;15;35,highIncome:15;35,Europe:32;40;35,lowIncome:40,highIncome:75;75
 feShare_space_heating_elec;EI and RC high, MC close to technical potential;40;40;60;40;60;40,Europe:37;75;40;40,highIncome:75;40,Europe:37;15;40,lowIncome:15,highIncome:17;17
 feShare_space_heating_heat;;35;30;25;35;25;15,Europe:25;6.25;35;15,highIncome:6.25;15,Europe:25;15;15,highIncome:3;3

--- a/man/splitElec.Rd
+++ b/man/splitElec.Rd
@@ -4,12 +4,10 @@
 \alias{splitElec}
 \title{Split heat pump and resistive electric fe and ue}
 \usage{
-splitElec(df, feueEff, enduseChar, scenAssump, endOfHistory)
+splitElec(df, enduseChar, scenAssump, endOfHistory)
 }
 \arguments{
 \item{df}{data frame containing share and efficiency data}
-
-\item{feueEff}{historical and future FE->UE conversion efficiencies}
 
 \item{enduseChar}{character, enduse for which electric FE demand should be split}
 


### PR DESCRIPTION
## Purpose of this PR
- Reduce the changes in the SSP2_GP scenario compared to SSP2 to keep only those which are tractable and can be compared to the scenario protocol.

## Implementation changes
- Remove the following changes in the SSP2_GP scenario compared to SSP2
  - Improvement of U-values (not tractable for the purpose of the scenario protocol)
  - Improvement of space cooling efficiency (already at levels required by scenario protocol)
  - Improvement of appliances and lighting efficiency (not tractable for the purpose of the scenario protocol).
- Keep the following changes: Increased heat pump share and efficiency, higher electric heating and electric cooking share.
- Also write heat pump and resistive electric heating share and efficiency to the output file; restructure the function `splitElec` for that purpose.

## Remarks/Caveat
- ~~Still requires the merge of #51 and rebasing~~
- The shares and efficiencies for the region `GLO` should probably be computed as a weighted average. This was omitted for reasons of simplicity. Should be changed at some point, but can maybe be done at a later stage.